### PR TITLE
GH-45: Add `@Import(ScriptVarGenConfig.class)`

### DIFF
--- a/spring-cloud-starter-stream-sink-router/README.adoc
+++ b/spring-cloud-starter-stream-sink-router/README.adoc
@@ -1,7 +1,7 @@
 //tag::ref-doc[]
 = Router Sink
 
-This module routes messages to named channels.
+This application routes messages to named channels.
 
 == Options
 

--- a/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/RouterSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/RouterSinkConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.groovy.GroovyScriptExecutingMessageProcessor;
 import org.springframework.integration.router.AbstractMappingMessageRouter;
@@ -34,10 +35,13 @@ import org.springframework.scripting.ScriptSource;
 
 /**
  * A sink app that routes to one or more named channels.
+ *
  * @author Gary Russell
+ * @author Artem Bilan
  */
 @EnableBinding(Sink.class)
 @EnableConfigurationProperties(RouterSinkProperties.class)
+@Import(ScriptVariableGeneratorConfiguration.class)
 public class RouterSinkConfiguration {
 
 	@Autowired

--- a/spring-cloud-starter-stream-sink-router/src/test/java/org/springframework/cloud/stream/app/router/sink/RouterSinkTests.java
+++ b/spring-cloud-starter-stream-sink-router/src/test/java/org/springframework/cloud/stream/app/router/sink/RouterSinkTests.java
@@ -26,30 +26,31 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.IntegrationTest;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.binder.BinderFactory;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.cloud.stream.test.binder.TestSupportBinder;
+import org.springframework.context.annotation.Import;
 import org.springframework.integration.router.AbstractMappingMessageRouter;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * Tests for RouterSinkConfiguration.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = RouterSinkTests.RouterSinkApplication.class)
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @DirtiesContext
-@WebIntegrationTest(randomPort = true)
 public abstract class RouterSinkTests {
 
 	@Autowired
@@ -64,7 +65,7 @@ public abstract class RouterSinkTests {
 	@Autowired
 	protected AbstractMappingMessageRouter router;
 
-	@IntegrationTest({ "router.resolutionRequired = true" })
+	@TestPropertySource(properties = "router.resolutionRequired = true")
 	public static class DefaultRouterTests extends RouterSinkTests {
 
 		@Test
@@ -85,7 +86,9 @@ public abstract class RouterSinkTests {
 
 	}
 
-	@IntegrationTest({ "router.expression = headers['route']", "router.resolutionRequired = true" })
+	@TestPropertySource(properties = {
+			"router.expression = headers['route']",
+			"router.resolutionRequired = true" })
 	public static class DefaultRouterWithExpressionTests extends RouterSinkTests {
 
 		@Test
@@ -106,7 +109,9 @@ public abstract class RouterSinkTests {
 
 	}
 
-	@IntegrationTest({ "router.expression = headers['route']", "router.destinationMappings = foo=baz \\n bar=qux",
+	@TestPropertySource(properties = {
+			"router.expression = headers['route']",
+			"router.destinationMappings = foo=baz \\n bar=qux",
 			"router.resolutionRequired = true" })
 	public static class WithChannelMappingsTests extends RouterSinkTests {
 
@@ -128,8 +133,10 @@ public abstract class RouterSinkTests {
 
 	}
 
-	@IntegrationTest({ "router.expression = headers['route']", "router.defaultOutputChannel = discards",
-		"spring.cloud.stream.dynamicDestinations = foo,bar,discards" })
+	@TestPropertySource(properties = {
+			"router.expression = headers['route']",
+			"router.defaultOutputChannel = discards",
+			"spring.cloud.stream.dynamicDestinations = foo,bar,discards" })
 	public static class WithDiscardChannelTests extends RouterSinkTests {
 
 		@Test
@@ -156,8 +163,10 @@ public abstract class RouterSinkTests {
 
 	}
 
-	@IntegrationTest({ "router.script = classpath:/routertest.groovy", "router.variables = foo=baz",
-		"router.variablesLocation = classpath:/routertest.properties" })
+	@TestPropertySource(properties = {
+			"router.script = classpath:/routertest.groovy",
+			"router.variables = foo=baz",
+			"router.variablesLocation = classpath:/routertest.properties" })
 	public static class WithGroovyTests extends RouterSinkTests {
 
 		@Test
@@ -178,7 +187,10 @@ public abstract class RouterSinkTests {
 
 	}
 
-	@SpringBootApplication
+	// Avoid @SpringBootApplication with its @ComponentScan
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	@Import(RouterSinkConfiguration.class)
 	public static class RouterSinkApplication {
 
 	}


### PR DESCRIPTION
Fixes GH-45 (https://github.com/spring-cloud-stream-app-starters/app-starters-release/issues/45)

Since we have `RouterSinkTests` in the same package as an original `RouterSinkConfiguration` and uses `@ComponentScan` from the `@SpringBootApplication`,
 we pick up unimported `ScriptVariableGeneratorConfiguration` as well for test environment.
In the real world `@SpringBootApplication` might be on a different package therefore  unimported `ScriptVariableGeneratorConfiguration` isn't scanned.

* Add `@Import(ScriptVariableGeneratorConfiguration.class)` to the `RouterSinkConfiguration`
* Modify `RouterSinkTests` do not scan packages
* Resolve deprecations according Spring Boot upgrade