### PR TITLE
Router cyclic dependencies

### DIFF
--- a/spring-cloud-starter-stream-sink-router/README.adoc
+++ b/spring-cloud-starter-stream-sink-router/README.adoc
@@ -24,7 +24,7 @@ The **$$router$$** $$sink$$ has the following options:
 //tag::configuration-properties[]
 $$router.default-output-channel$$:: $$Where to send unroutable messages.$$ *($$String$$, default: `$$nullChannel$$`)*
 $$router.destination-mappings$$:: $$Destination mappings as a new line delimited string of name-value pairs, e.g. 'foo=bar\n baz=car'.$$ *($$Properties$$, default: `$$<none>$$`)*
-$$router.expression$$:: $$The expression to be applied to the message to determine the channel(s) to route to. When text/json 'payload' is used in the expression you should convert it into string first: 'new String(payload)'$$ *($$Expression$$, default: `$$<none>$$`)*
+$$router.expression$$:: $$The expression to be applied to the message to determine the channel(s) to route to. Note that the payload wire format for content types such as text, json or xml is byte[] not String!. Consult the documentation for how to handle byte array payload content.$$ *($$Expression$$, default: `$$<none>$$`)*
 $$router.refresh-delay$$:: $$How often to check for script changes in ms (if present); < 0 means don't refresh.$$ *($$Integer$$, default: `$$60000$$`)*
 $$router.resolution-required$$:: $$Whether or not channel resolution is required.$$ *($$Boolean$$, default: `$$false$$`)*
 $$router.script$$:: $$The location of a groovy script that returns channels or channel mapping resolution keys.$$ *($$Resource$$, default: `$$<none>$$`)*
@@ -51,11 +51,15 @@ For more information, please see the "Routers and the Spring Expression Language
 Integration Reference manual
 http://docs.spring.io/spring-integration/reference/html/messaging-routing-chapter.html#router-namespace[Configuring (Generic) Router section].
 
-NOTE: Starting with SCSt (Spring Cloud Stream) 2.0 the message wire format for `json`, `text` and `xml` content types is `byte[]` not String.
-The SpEL expressions for those content-types will either need to convert the payload to `String` or use the `jsonPath`
-or `xmlPath` utils that handle byte array payloads.
+NOTE: Starting with Spring Cloud Stream 2.0 onwards the message wire format for `json`, `text` and `xml` content types is `byte[]` not `String`!
+This is an altering change from SCSt 1.x that treats those types as Strings!
+Depends on the content type, different techniques for handling the `byte[]` payloads are available. For plain `text`
+content types, one can covert the octet payload into string using the `new String(payload)` SpEL expression. For `json`
+types the https://docs.spring.io/spring-integration/reference/html/spel.html#spel-functions[jsonPath()] SpEL utility
+already supports string and byte array content interchangeably. Same applies for the `xml` content type and the
+https://docs.spring.io/spring-integration/reference/html/xml.html#xpath-spel-function[#xpath()] SpEL utility.
 
-For example for text content type one should use:
+For example for `text` content type one should use:
 
 [source]
 ----

--- a/spring-cloud-starter-stream-sink-router/README.adoc
+++ b/spring-cloud-starter-stream-sink-router/README.adoc
@@ -51,6 +51,24 @@ For more information, please see the "Routers and the Spring Expression Language
 Integration Reference manual
 http://docs.spring.io/spring-integration/reference/html/messaging-routing-chapter.html#router-namespace[Configuring (Generic) Router section].
 
+NOTE: Starting with SCSt (Spring Cloud Stream) 2.0 the message wire format for `json`, `text` and `xml` content types is `byte[]` not String.
+The SpEL expressions for those content-types will either need to convert the payload to `String` or use the `jsonPath`
+or `xmlPath` utils that handle byte array payloads.
+
+For example for text content type one should use:
+
+[source]
+----
+ new String(payload).contains('a')
+----
+
+and for `json` content type SpEL expressions like this:
+
+[source]
+----
+ #jsonPath(payload, '$.person.name')
+----
+
 == Groovy-based Routing
 
 Instead of SpEL expressions, Groovy scripts can also be used. Let's create a Groovy script in the file system at

--- a/spring-cloud-starter-stream-sink-router/README.adoc
+++ b/spring-cloud-starter-stream-sink-router/README.adoc
@@ -24,12 +24,10 @@ The **$$router$$** $$sink$$ has the following options:
 //tag::configuration-properties[]
 $$router.default-output-channel$$:: $$Where to send unroutable messages.$$ *($$String$$, default: `$$nullChannel$$`)*
 $$router.destination-mappings$$:: $$Destination mappings as a new line delimited string of name-value pairs, e.g. 'foo=bar\n baz=car'.$$ *($$Properties$$, default: `$$<none>$$`)*
-$$router.expression$$:: $$The expression to be applied to the message to determine the channel(s)
- to route to.$$ *($$Expression$$, default: `$$<none>$$`)*
+$$router.expression$$:: $$The expression to be applied to the message to determine the channel(s) to route to. When text/json 'payload' is used in the expression you should convert it into string first: 'new String(payload)'$$ *($$Expression$$, default: `$$<none>$$`)*
 $$router.refresh-delay$$:: $$How often to check for script changes in ms (if present); < 0 means don't refresh.$$ *($$Integer$$, default: `$$60000$$`)*
 $$router.resolution-required$$:: $$Whether or not channel resolution is required.$$ *($$Boolean$$, default: `$$false$$`)*
-$$router.script$$:: $$The location of a groovy script that returns channels or channel mapping
- resolution keys.$$ *($$Resource$$, default: `$$<none>$$`)*
+$$router.script$$:: $$The location of a groovy script that returns channels or channel mapping resolution keys.$$ *($$Resource$$, default: `$$<none>$$`)*
 $$router.variables$$:: $$Variable bindings as a new line delimited string of name-value pairs, e.g. 'foo=bar\n baz=car'.$$ *($$Properties$$, default: `$$<none>$$`)*
 $$router.variables-location$$:: $$The location of a properties file containing custom script variable bindings.$$ *($$Resource$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
@@ -94,7 +92,7 @@ $ ./mvnw clean package
 == Examples
 
 ```
-java -jar router-sink.jar --expression=" "
+java -jar router-sink.jar --expression="new String(payload).contains('a')?':foo':':bar'"
 java -jar router-sink.jar --script=" "
 ```
 

--- a/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/RouterSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/RouterSinkConfiguration.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.stream.app.router.sink;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
@@ -28,6 +27,7 @@ import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.groovy.GroovyScriptExecutingMessageProcessor;
 import org.springframework.integration.router.AbstractMappingMessageRouter;
 import org.springframework.integration.router.ExpressionEvaluatingRouter;
+import org.springframework.integration.router.MessageRouter;
 import org.springframework.integration.router.MethodInvokingRouter;
 import org.springframework.integration.scripting.RefreshableResourceScriptSource;
 import org.springframework.integration.scripting.ScriptVariableGenerator;
@@ -38,18 +38,16 @@ import org.springframework.scripting.ScriptSource;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Christian Tzolov
  */
 @EnableBinding(Sink.class)
 @EnableConfigurationProperties(RouterSinkProperties.class)
 @Import(ScriptVariableGeneratorConfiguration.class)
 public class RouterSinkConfiguration {
 
-	@Autowired
-	Sink channels;
-
 	@Bean
 	@ServiceActivator(inputChannel = Sink.INPUT)
-	public AbstractMappingMessageRouter router(BinderAwareChannelResolver channelResolver,
+	public MessageRouter router(BinderAwareChannelResolver channelResolver,
 			ScriptVariableGenerator scriptVariableGenerator, RouterSinkProperties properties) {
 		AbstractMappingMessageRouter router;
 		if (properties.getScript() != null) {

--- a/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/RouterSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/RouterSinkProperties.java
@@ -50,9 +50,9 @@ public class RouterSinkProperties {
 	private Resource variablesLocation;
 
 	/**
-	 * The expression to be applied to the message to determine the channel(s)
-	 * to route to. When text/json 'payload' is used in the expression you should convert it into string first:
-	 * 'new String(payload)'
+	 * The expression to be applied to the message to determine the channel(s) to route to.
+	 * Note that the payload wire format for content types such as text, json or xml is byte[] not String!.
+	 * Consult the documentation for how to handle byte array payload content.
 	 */
 	private Expression expression = DEFAULT_EXPRESSION;
 

--- a/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/RouterSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-router/src/main/java/org/springframework/cloud/stream/app/router/sink/RouterSinkProperties.java
@@ -51,7 +51,8 @@ public class RouterSinkProperties {
 
 	/**
 	 * The expression to be applied to the message to determine the channel(s)
-	 * to route to.
+	 * to route to. When text/json 'payload' is used in the expression you should convert it into string first:
+	 * 'new String(payload)'
 	 */
 	private Expression expression = DEFAULT_EXPRESSION;
 


### PR DESCRIPTION
  - Replace return bean type from AbstractMappingMessageRouter to the MessageRouter interface.
  - Add example to explain that that 'new String(payload)' is required for TEXT and JSON payloads.
  - Remove redundant code.

  Resolves https://github.com/spring-cloud-stream-app-starters/app-starters-release/issues/163
